### PR TITLE
Fix headers path for 2.7

### DIFF
--- a/ext/digest/whirlpool/depend
+++ b/ext/digest/whirlpool/depend
@@ -2,5 +2,5 @@ whirlpool-algorithm.o: whirlpool-algorithm.c whirlpool-algorithm.h \
   whirlpool-portability.h whirlpool-constants.h
 whirlpool.o: whirlpool.c whirlpool-algorithm.h whirlpool-portability.h \
   whirlpool-constants.h \
-  $(hdrdir)/digest.h $(hdrdir)/ruby.h \
-  $(topdir)/config.h $(hdrdir)/defines.h $(hdrdir)/intern.h
+  $(hdrdir)/ruby/digest.h $(hdrdir)/ruby.h \
+  $(topdir)/config.h $(hdrdir)/ruby/defines.h $(hdrdir)/ruby/intern.h


### PR DESCRIPTION
Since this commit https://github.com/ruby/ruby/commit/3d1c86a26f0c96a9c1d0247b968aa96e6f3c30bb#diff-7aa560cb6196deeb96779cd175e8e589L2118

mkmf doesn't change the path to ruby headers.